### PR TITLE
NETOBSERV-113 goflow2 kafka

### DIFF
--- a/examples/goflow2-kafka.yaml
+++ b/examples/goflow2-kafka.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: goflow2
+  name: goflow2
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: goflow2
+  template:
+    metadata:
+      labels:
+        app: goflow2
+    spec:
+      volumes:
+        - name: config-vol
+          configMap:
+            name: goflow2-config
+      containers:
+        - command:
+            - /bin/sh
+            - -c
+            - /goflow2 -loglevel=trace -listen=netflow://:2055 -transport=kafka -transport.kafka.brokers=my-cluster-kafka-brokers.openshift-operators.svc.cluster.local:9092 -transport.kafka.topic=goflow-kube -transport.kafka.hashing=true -format.hash=TimeReceived,SamplerAddress,SrcAddr,SrcPort,SrcMac,DstAddress,DstPort,DstMac
+          image: quay.io/netobserv/goflow2:main
+          imagePullPolicy: IfNotPresent
+          name: goflow2
+          resources:
+            limits:
+              memory: 512Mi
+              cpu: "1"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: goflow2
+  namespace: default
+  labels:
+    app: goflow2
+spec:
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: metrics
+    - port: 2055
+      protocol: UDP
+      name: netflow
+  selector:
+    app: goflow2

--- a/examples/goflow2-kafka.yaml
+++ b/examples/goflow2-kafka.yaml
@@ -23,7 +23,7 @@ spec:
         - command:
             - /bin/sh
             - -c
-            - /goflow2 -loglevel=trace -listen=netflow://:2055 -transport=kafka -transport.kafka.brokers=my-cluster-kafka-brokers.openshift-operators.svc.cluster.local:9092 -transport.kafka.topic=goflow-kube -transport.kafka.hashing=true -format.hash=TimeReceived,SamplerAddress,SrcAddr,SrcPort,SrcMac,DstAddress,DstPort,DstMac
+            - /goflow2 -loglevel=trace -listen=netflow://:2055 -transport=kafka -transport.kafka.brokers=my-cluster-kafka-brokers.default.svc.cluster.local:9092 -transport.kafka.topic=goflow-kube -transport.kafka.hashing=true -format.hash=TimeReceived,SamplerAddress,SrcAddr,SrcPort,SrcMac,DstAddress,DstPort,DstMac
           image: quay.io/netobserv/goflow2:main
           imagePullPolicy: IfNotPresent
           name: goflow2

--- a/examples/kowl.yaml
+++ b/examples/kowl.yaml
@@ -1,0 +1,23 @@
+# may be needed if security contraints of k8s cluster expect a custom user range 
+podSecurityContext: {runAsUser: 1001190000, fsGroup: 1001190000}
+
+# configuration of kowl
+kowl:
+  # See reference config: https://github.com/cloudhut/kowl/blob/master/docs/config/kowl.yaml)
+  config:
+    kafka:
+      brokers:
+        # Set your bootstrap url. Kowl does domain name validation so be sure to pick a valid url which is covered in the subject alternative name of the certificate of the bootsrap endpoint (e.g. no <namespace>.svc.cluster.local address).
+        -  my-cluster-kafka-bootstrap:9093
+      tls:
+        enabled: true
+        caFilepath: /etc/strimzi/ca/ca.crt
+extraVolumeMounts: |-
+  - name: strimzi-ca
+    mountPath: /etc/strimzi/ca
+    readOnly: true
+extraVolumes: |-
+  - name: strimzi-ca
+    secret:
+      # you need to prefix this secret name with the name of you cluster
+      secretName: my-cluster-cluster-ca-cert

--- a/kafka.md
+++ b/kafka.md
@@ -3,7 +3,7 @@
 The easiest way to deploy Kafka on Openshift is using [Strimzi](https://strimzi.io/).
 An Operator is available in OperatorHub section. Simply install it and create a "Kafka" instance.
 
-The default settings will create a bunch of Kafka Brokers and Zookeepers in `openshift-operators` namespace.
+The default settings will create a bunch of Kafka Brokers and Zookeepers in `default` namespace.
 
 # Deploy goflow2 as Kafka Producer
 
@@ -13,7 +13,7 @@ Edit command arguments according to your needs:
 `-loglevel=trace` to set logrus log level to trace
 `-listen=netflow://:2055` defines netflow version and listening port
 `-transport=kafka` will send output to kafka 
-`-transport.kafka.brokers=my-cluster-kafka-brokers.openshift-operators.svc.cluster.local:9092` set the kafka broker url and port
+`-transport.kafka.brokers=my-cluster-kafka-brokers.default.svc.cluster.local:9092` set the kafka broker url and port
 `-transport.kafka.topic=goflow-kube` set the kafka topic 
 `-transport.kafka.hashing=true` allow partition
 `-format.hash=TimeReceived,SamplerAddress,SrcAddr,SrcPort,SrcMac,DstAddress,DstPort,DstMac` fields used for partition hash
@@ -21,6 +21,38 @@ Edit command arguments according to your needs:
 Then deploy goflow2:
 ```
 oc apply -f examples/goflow2-kafka.yaml
+```
+
+You can optionally create a route to view metrics using the following configuration:
+```yaml
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: goflow2
+  namespace: default
+spec:
+  path: /metrics
+  to:
+    kind: Service
+    name: goflow2
+    weight: 100
+  port:
+    targetPort: metrics
+  wildcardPolicy: None
+```
+
+As soon as `goflow2` will send it's firsts flows, you will see a new Kafka Topic in Installed Operators > Strimzi Operator details > Kafka Topics
+Here we expect `goflow-kube`
+
+You can edit the associated yaml to increase partition number:
+```yaml
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+spec:
+  ...
+  partitions: 5
+  ...
+  topicName: goflow-kube
 ```
 
 # Deploy kube-enricher as Kafka Consumer
@@ -36,9 +68,9 @@ metadata:
   name: goflow-kube-kafka-config
 data:
   config.yaml: |
-    listen: my-cluster-kafka-bootstrap.openshift-operators.svc.cluster.local:9092
+    listen: my-cluster-kafka-bootstrap.default.svc.cluster.local:9092
     kafka:
-      version 3.0.0
+      version: 3.0.0
 ```
 
 By default the following options will be used:
@@ -53,3 +85,22 @@ Topic:               "goflow-kube",
 
 Check [config.go](https://github.com/netobserv/goflow2-kube-enricher/blob/main/pkg/config/config.go) for more details
 
+# Web UI for Kafka using Kowl
+Check [kowl.yaml](examples/kowl.yaml) file and update broker URL and extraVolumes if needed.
+
+Then run the following commands to create a Kowl instance:
+```bash
+helm repo add cloudhut https://raw.githubusercontent.com/cloudhut/charts/master/archives
+helm repo update
+helm upgrade --install -f examples/kowl.yaml kowl cloudhut/kowl
+```
+
+You should get a prompt showing status `deployed`
+
+Then run:
+```
+export POD_NAME=$(kubectl get pods --namespace default -l "app.kubernetes.io/name=kowl,app.kubernetes.io/instance=kowl" -o jsonpath="{.items[0].metadata.name}")
+kubectl --namespace default port-forward $POD_NAME 8080:8080
+```
+
+Open `http://127.0.0.1:8080` to access kowl.

--- a/kafka.md
+++ b/kafka.md
@@ -16,6 +16,22 @@ Edit brokers parameter according to your needs and run:
 oc apply -f examples/goflow-kube-kafka-exporter.yaml
 ```
 
+You can set fields used for partition hash by setting `hashKeys`:
+```yaml
+  config.yaml: |
+    ...
+    kafka:
+      version: 3.0.0
+      export:
+        hashKeys:
+          - TimeReceived
+          - SrcAddr
+          - SrcMac
+          - DstAddr
+          - DstMac
+```
+Else it will choose partition randomly.
+
 By default the following options will be used:
 ```go
 Version: "2.8.0",
@@ -23,7 +39,7 @@ TLS:     false,
 SASL:    nil,
 Topic:   "goflow-kube",
 ...
-Hashing:        false,
+Keys:           []string{},
 Brokers:        []string{},
 MaxMsgBytes:    1024 * 1024,      // 1mb
 FlushBytes:     10 * 1024 * 1024, // 10 mb

--- a/kafka.md
+++ b/kafka.md
@@ -1,0 +1,55 @@
+# Deploy Kafka on Openshift using Strimzi Operator
+
+The easiest way to deploy Kafka on Openshift is using [Strimzi](https://strimzi.io/).
+An Operator is available in OperatorHub section. Simply install it and create a "Kafka" instance.
+
+The default settings will create a bunch of Kafka Brokers and Zookeepers in `openshift-operators` namespace.
+
+# Deploy goflow2 as Kafka Producer
+
+Take a look at file [goflow2-karka.yaml](./examples/goflow2-kafka.yaml)
+
+Edit command arguments according to your needs:
+`-loglevel=trace` to set logrus log level to trace
+`-listen=netflow://:2055` defines netflow version and listening port
+`-transport=kafka` will send output to kafka 
+`-transport.kafka.brokers=my-cluster-kafka-brokers.openshift-operators.svc.cluster.local:9092` set the kafka broker url and port
+`-transport.kafka.topic=goflow-kube` set the kafka topic 
+`-transport.kafka.hashing=true` allow partition
+`-format.hash=TimeReceived,SamplerAddress,SrcAddr,SrcPort,SrcMac,DstAddress,DstPort,DstMac` fields used for partition hash
+
+Then deploy goflow2:
+```
+oc apply -f examples/goflow2-kafka.yaml
+```
+
+# Deploy kube-enricher as Kafka Consumer
+
+Check [goflow-kube-kafka.yaml](https://github.com/netobserv/goflow2-kube-enricher/blob/main/examples/goflow-kube-legacy.yaml) in `goflow2-kube-enricher/examples/`
+
+You will need to specify kafka broker url and port in the `listen` config option and optionally `version` in `kafka` section. 
+```yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: goflow-kube-kafka-config
+data:
+  config.yaml: |
+    listen: my-cluster-kafka-bootstrap.openshift-operators.svc.cluster.local:9092
+    kafka:
+      version 3.0.0
+```
+
+By default the following options will be used:
+```go
+Group:               "goflow-kube",
+BalanceStrategy:     "range",
+InitialOffsetOldest: true,
+Version:             "2.8.0",
+TLS:                 false,
+Topic:               "goflow-kube",
+```
+
+Check [config.go](https://github.com/netobserv/goflow2-kube-enricher/blob/main/pkg/config/config.go) for more details
+


### PR DESCRIPTION
This is an example of `kube-enricher` / `goflow2` as Producer + `kube-enricher` as Consumer for kafka using Strimzi Operator

Check [this PR](https://github.com/netobserv/goflow2-kube-enricher/pull/21) for related code changes

Also this show how to run [Kowl](https://github.com/cloudhut/kowl)

![image](https://user-images.githubusercontent.com/91894519/150793075-01802903-db79-4d73-a1f4-971ae26bd959.png)

![image](https://user-images.githubusercontent.com/91894519/150792757-41034943-1b7a-485f-a8a5-b21708cc9f03.png)

