### PR TITLE
NETOBSERV-426 : Loki tls

### DIFF
--- a/examples/zero-click-loki/2-loki-tls.yaml
+++ b/examples/zero-click-loki/2-loki-tls.yaml
@@ -1,0 +1,130 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-config
+data:
+  local-config.yaml: |
+    auth_enabled: false
+    server:
+      http_listen_port: 3100
+      grpc_listen_port: 9096
+      http_server_read_timeout: 1m
+      http_server_write_timeout: 1m
+      log_level: error
+    target: all
+    common:
+      path_prefix: /loki-store
+      storage:
+        filesystem:
+          chunks_directory: /loki-store/chunks
+          rules_directory: /loki-store/rules
+      replication_factor: 1
+      ring:
+        instance_addr: 127.0.0.1
+        kvstore:
+          store: inmemory
+    compactor:
+      compaction_interval: 5m
+    frontend:
+      compress_responses: true
+    ingester:
+      chunk_encoding: snappy
+      chunk_retain_period: 1m
+    query_range:
+      align_queries_with_step: true
+      cache_results: true
+      max_retries: 5
+      results_cache:
+        cache:
+          enable_fifocache: true
+          fifocache:
+            max_size_bytes: 500MB
+            validity: 24h
+      parallelise_shardable_queries: true
+    schema_config:
+      configs:
+        - from: 2022-01-01
+          store: boltdb-shipper
+          object_store: filesystem
+          schema: v11
+          index:
+            prefix: index_
+            period: 24h
+    storage_config:
+      filesystem:
+        directory: /loki-store/storage
+      boltdb_shipper:
+        active_index_directory: /loki-store/index
+        shared_store: filesystem
+        cache_location: /loki-store/boltdb-cache
+        cache_ttl: 24h
+    limits_config:    
+      ingestion_rate_strategy: global 
+      ingestion_rate_mb: 4
+      ingestion_burst_size_mb: 6
+      max_label_name_length: 1024
+      max_label_value_length: 2048
+      max_label_names_per_series: 30
+      reject_old_samples: true
+      reject_old_samples_max_age: 15m
+      creation_grace_period: 10m
+      enforce_metric_name: false
+      max_line_size: 256000
+      max_line_size_truncate: false
+      max_entries_limit_per_query: 10000
+      max_streams_per_user: 0
+      max_global_streams_per_user: 0
+      unordered_writes: true
+      max_chunks_per_query: 2000000
+      max_query_length: 721h
+      max_query_parallelism: 32
+      max_query_series: 10000
+      cardinality_limit: 100000
+      max_streams_matchers_per_query: 1000
+      max_concurrent_tail_requests: 10
+      retention_period: 24h
+      max_cache_freshness_per_query: 5m
+      max_queriers_per_tenant: 0
+      per_stream_rate_limit: 3MB
+      per_stream_rate_limit_burst: 15MB
+      max_query_lookback: 0
+      min_sharding_lookback: 0s
+      split_queries_by_interval: 1m
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: loki
+  labels:
+    app: loki
+spec:
+  securityContext:
+    runAsGroup: 1000
+    runAsUser: 1000
+    fsGroup: 1000
+  volumes:
+    - name: loki-store
+      persistentVolumeClaim:
+        claimName: loki-store
+    - name: loki-config
+      configMap:
+        name: loki-config
+  containers:
+    - name: loki
+      image: grafana/loki:2.5.0
+      volumeMounts:
+        - mountPath: "/loki-store"
+          name: loki-store
+        - mountPath: "/etc/loki"
+          name: loki-config
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: loki
+spec:
+  selector:
+    app: loki
+  ports:
+    - port: 3100
+      protocol: TCP

--- a/examples/zero-click-loki/2-loki-tls.yaml
+++ b/examples/zero-click-loki/2-loki-tls.yaml
@@ -61,8 +61,8 @@ data:
         shared_store: filesystem
         cache_location: /loki-store/boltdb-cache
         cache_ttl: 24h
-    limits_config:    
-      ingestion_rate_strategy: global 
+    limits_config:
+      ingestion_rate_strategy: global
       ingestion_rate_mb: 4
       ingestion_burst_size_mb: 6
       max_label_name_length: 1024
@@ -139,3 +139,10 @@ spec:
   ports:
     - port: 3100
       protocol: TCP
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"

--- a/examples/zero-click-loki/2-loki-tls.yaml
+++ b/examples/zero-click-loki/2-loki-tls.yaml
@@ -7,6 +7,9 @@ data:
     auth_enabled: false
     server:
       http_listen_port: 3100
+      http_tls_config: &tls_server_config
+        cert_file: /var/serving-cert/tls.crt
+        key_file:  /var/serving-cert/tls.key
       grpc_listen_port: 9096
       http_server_read_timeout: 1m
       http_server_write_timeout: 1m
@@ -109,6 +112,9 @@ spec:
     - name: loki-config
       configMap:
         name: loki-config
+    - name: certs
+      secret:
+        secretName: loki
   containers:
     - name: loki
       image: grafana/loki:2.5.0
@@ -117,11 +123,16 @@ spec:
           name: loki-store
         - mountPath: "/etc/loki"
           name: loki-config
+        - mountPath: "/var/serving-cert"
+          name: certs
+          readOnly: true
 ---
 kind: Service
 apiVersion: v1
 metadata:
   name: loki
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: loki
 spec:
   selector:
     app: loki


### PR DESCRIPTION
Added loki tls configuration using openshift annotation. To keep compatibility with vanilla kubernetes I duplicated the loki zero click configuration.

You will have a better view of what has been added looking at the second commit:
https://github.com/netobserv/documents/commit/08dd3b5bc3fa66de67ab048ba5cd60679cb179ea