### PR TITLE
NETOBSERV-374 - Improve the 0-click Loki install

### DIFF
--- a/examples/distributed-loki/1-prerequisites/secret.yaml
+++ b/examples/distributed-loki/1-prerequisites/secret.yaml
@@ -1,0 +1,10 @@
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: loki-distributed
+  namespace: network-observability
+type: Opaque
+stringData:
+  ACCESS_KEY_ID: XXXXXXXXXXXXXXXXXXXX
+  SECRET_ACCESS_KEY: YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY

--- a/examples/distributed-loki/1-prerequisites/service-account.yaml
+++ b/examples/distributed-loki/1-prerequisites/service-account.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/name: loki-distributed
     app.kubernetes.io/version: 2.5.0
 secrets:
+  - name: loki-distributed
   - name: loki-distributed-token
   - name: loki-distributed-dockercfg
 imagePullSecrets:

--- a/examples/distributed-loki/2-components/distributor-deployment.yaml
+++ b/examples/distributed-loki/2-components/distributor-deployment.yaml
@@ -84,7 +84,19 @@ spec:
           image: 'grafana/loki:2.5.0'
           args:
             - '-config.file=/etc/loki/config/config.yaml'
+            - '-config.expand-env=true'
             - '-target=distributor'
+          env:
+            - name: ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef: 
+                  name: loki-distributed
+                  key: ACCESS_KEY_ID
+            - name: SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef: 
+                  name: loki-distributed
+                  key: SECRET_ACCESS_KEY
       serviceAccount: loki-distributed
       volumes:
         - name: config

--- a/examples/distributed-loki/2-components/ingester-statefulset.yaml
+++ b/examples/distributed-loki/2-components/ingester-statefulset.yaml
@@ -86,7 +86,19 @@ spec:
           image: 'grafana/loki:2.5.0'
           args:
             - '-config.file=/etc/loki/config/config.yaml'
+            - '-config.expand-env=true'
             - '-target=ingester'
+          env:
+            - name: ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef: 
+                  name: loki-distributed
+                  key: ACCESS_KEY_ID
+            - name: SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef: 
+                  name: loki-distributed
+                  key: SECRET_ACCESS_KEY
       serviceAccount: loki-distributed
       volumes:
         - name: config

--- a/examples/distributed-loki/2-components/querier-statefulset.yaml
+++ b/examples/distributed-loki/2-components/querier-statefulset.yaml
@@ -86,7 +86,19 @@ spec:
           image: 'grafana/loki:2.5.0'
           args:
             - '-config.file=/etc/loki/config/config.yaml'
+            - '-config.expand-env=true'
             - '-target=querier'
+          env:
+            - name: ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef: 
+                  name: loki-distributed
+                  key: ACCESS_KEY_ID
+            - name: SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef: 
+                  name: loki-distributed
+                  key: SECRET_ACCESS_KEY
       serviceAccount: loki-distributed
       volumes:
         - name: config

--- a/examples/distributed-loki/2-components/query-frontend-deployment.yaml
+++ b/examples/distributed-loki/2-components/query-frontend-deployment.yaml
@@ -69,7 +69,19 @@ spec:
           image: 'grafana/loki:2.5.0'
           args:
             - '-config.file=/etc/loki/config/config.yaml'
+            - '-config.expand-env=true'
             - '-target=query-frontend'
+          env:
+            - name: ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef: 
+                  name: loki-distributed
+                  key: ACCESS_KEY_ID
+            - name: SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef: 
+                  name: loki-distributed
+                  key: SECRET_ACCESS_KEY
       serviceAccount: loki-distributed
       volumes:
         - name: config

--- a/loki_distributed.md
+++ b/loki_distributed.md
@@ -38,9 +38,11 @@ Note that `querier` and `ingester` has alternative services with `-headless` suf
 An additionnal service called `loki-distributed-memberlist` will match all the components and allow discoverability between them.
 
 ## Storage configuration
+Edit [loki Secret](./examples/distributed-loki/1-prerequisites/secret.yaml) and replace `ACCESS_KEY_ID` and `SECRET_ACCESS_KEY` values with your bucket credentials. These will be loaded in environment variables and can be reused in config as `${ACCESS_KEY_ID}` and `${SECRET_ACCESS_KEY}`.
+
 Edit [loki ConfigMap](./examples/distributed-loki/1-prerequisites/config.yaml) and replace `$(LOKI_STORE_NAME)` and `$(LOKI_STORE)` with your proper external storage configuration.
 
-Example using `s3` bucket called `loki` in `us-east-1` region:
+Example using `s3` bucket called `loki` in `us-east-1` region with credentials from secret:
 ```yaml
   config.yaml: |
     ...
@@ -50,8 +52,8 @@ Example using `s3` bucket called `loki` in `us-east-1` region:
           s3: https://s3.us-east-1.amazonaws.com
           bucketnames: loki
           region: us-east-1
-          access_key_id: XXXXXXXXXXXXXXXXXXXX
-          secret_access_key: YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY
+          access_key_id: ${ACCESS_KEY_ID}
+          secret_access_key: ${SECRET_ACCESS_KEY}
           s3forcepathstyle: true
     ...
     schema_config:


### PR DESCRIPTION
Following our [Jira discussion](https://issues.redhat.com/browse/NETOBSERV-374) we can load credentials from secret mounted as environment variable and injected in the loki config.