### PR TITLE
Fix Loki parallelization issue

### DIFF
--- a/examples/zero-click-loki/2-loki-tls.yaml
+++ b/examples/zero-click-loki/2-loki-tls.yaml
@@ -44,6 +44,8 @@ data:
             max_size_bytes: 500MB
             validity: 24h
       parallelise_shardable_queries: true
+    query_scheduler:
+      max_outstanding_requests_per_tenant: 2048
     schema_config:
       configs:
         - from: 2022-01-01

--- a/examples/zero-click-loki/2-loki.yaml
+++ b/examples/zero-click-loki/2-loki.yaml
@@ -41,6 +41,8 @@ data:
             max_size_bytes: 500MB
             validity: 24h
       parallelise_shardable_queries: true
+    query_scheduler:
+      max_outstanding_requests_per_tenant: 2048
     schema_config:
       configs:
         - from: 2022-01-01


### PR DESCRIPTION
Need to increase a lot max_outstanding_requests_per_tenant because Loki may parallelize queries a lot, and then return errors when there's too many outstanding queries