### PR TITLE
NETOBSERV-677 - log cleanup/retention configs

### DIFF
--- a/examples/kafka/default.yaml
+++ b/examples/kafka/default.yaml
@@ -33,9 +33,10 @@ spec:
       log.cleaner.io.buffer.load.factor: 0.9
       log.cleaner.threads: 8
       log.cleanup.policy: delete
+      log.retention.bytes: 107374182400
       log.retention.check.interval.ms: 300000
       log.retention.ms: 1680000
-      log.roll.ms: 259200000
+      log.roll.ms: 7200000
       log.segment.bytes: 1073741824
     storage:
       type: persistent-claim 

--- a/examples/kafka/default.yaml
+++ b/examples/kafka/default.yaml
@@ -27,6 +27,16 @@ spec:
       min.insync.replicas: 1
       inter.broker.protocol.version: "3.1"
       auto.create.topics.enable: false
+      log.cleaner.backoff.ms: 15000
+      log.cleaner.dedupe.buffer.size: 134217728
+      log.cleaner.enable: true
+      log.cleaner.io.buffer.load.factor: 0.9
+      log.cleaner.threads: 8
+      log.cleanup.policy: delete
+      log.retention.check.interval.ms: 300000
+      log.retention.ms: 1680000
+      log.roll.ms: 259200000
+      log.segment.bytes: 1073741824
     storage:
       type: persistent-claim 
       size: 200Gi 


### PR DESCRIPTION
NETOBSERV-677
Configs referred from: https://strimzi.io/docs/operators/latest/full/configuring.html#managing_logs_with_data_retention_policies  
Clean up only happens when segment is rolled which is configured  as `log.roll.ms: 259200000` i.e. 3 days . Retention check happens ever 300000 ms (28 mins)