### PR TITLE
alerting/loki-ratelimit-alert.yaml

### DIFF
--- a/examples/distributed-loki/alerting/loki-ratelimit-alert.yaml
+++ b/examples/distributed-loki/alerting/loki-ratelimit-alert.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: loki-alerts
+  namespace: openshift-operators-redhat
+spec:
+  groups:
+  - name: LokiRateLimitAlerts
+    rules:
+    - alert: LokiTenantRateLimit
+      annotations:
+        message: |-
+          {{ $labels.job }} {{ $labels.route }} is experiencing 429 errors.
+        summary: "At any number of requests are responded with the rate limit error code."
+      expr: sum(irate(loki_request_duration_seconds_count{status_code="429"}[1m])) by (job, namespace, route) / sum(irate(loki_request_duration_seconds_count[1m])) by (job, namespace, route) * 100 > 0
+      for: 10s
+      labels:
+        severity: warning


### PR DESCRIPTION
Adding loki rate limit alert, it's currently configured to fire for any occurrence of 429s from Loki and set up for 2x  default of `maxBackoff` i.e. 10 seconds