### PR TITLE
Removed explict Kafka version from default.yaml

### DIFF
--- a/examples/kafka/default.yaml
+++ b/examples/kafka/default.yaml
@@ -4,7 +4,6 @@ metadata:
   name: kafka-cluster
 spec:
   kafka:
-    version: 3.2.0
     replicas: 1
     listeners:
       - name: plain


### PR DESCRIPTION
AMQ Streams Operator no longer supports Kafka `3.2.0` - needs to be bumped to `3.2.3` - see below logs:
```
io.strimzi.operator.cluster.model.KafkaVersion$UnsupportedKafkaVersionException: Unsupported Kafka.spec.kafka.version: 3.2.0. Supported versions are: [3.1.0, 3.2.3]
	at io.strimzi.operator.cluster.model.KafkaVersion$Lookup.supportedVersion(KafkaVersion.java:166) ~[io.strimzi.cluster-operator-0.29.0.redhat-00014.jar:0.29.0.redhat-00014]
	at io.strimzi.operator.cluster.operator.assembly.VersionChangeCreator.<init>(VersionChangeCreator.java:87) ~[io.strimzi.cluster-operator-0.29.0.redhat-00014.jar:0.29.0.redhat-00014]
```