### PR TITLE
NETOBSERV-1033: Lock down Network Observability

### DIFF
--- a/examples/lockdown-netobserv.yaml
+++ b/examples/lockdown-netobserv.yaml
@@ -1,0 +1,21 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: lockdown-netobserv
+  namespace: netobserv
+spec:
+  podSelector: {}
+  ingress:
+    - from:
+        - podSelector: {}  # without namespaceSelecor, it defaults to 'same namespace'
+        - podSelector: {}
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-console
+        - podSelector: {}
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-monitoring
+  policyTypes:
+    - Ingress
+status: {}


### PR DESCRIPTION
Network policy to lock down ingress traffic to 'netobserv' namespace

The Kubernetes API server sets the `kubernetes.io/metadata.name`  label on all namespaces. The label value is set to the name of the namespace. You can't change this label's value.  Therefore, it is safe to use in the network policy as the namespace selector.

Source: https://kubernetes.io/docs/reference/labels-annotations-taints/#:~:text=for%20more%20details.-,kubernetes.io/metadata.name,-Example%3A%20kubernetes