### PR TITLE
Bump Loki volume size from 1G to 200G

### DIFF
--- a/examples/zero-click-loki/1-storage.yaml
+++ b/examples/zero-click-loki/1-storage.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   resources:
     requests:
-      storage: 200G
+      storage: 10G
   volumeMode: Filesystem
   accessModes:
     - ReadWriteOnce

--- a/examples/zero-click-loki/1-storage.yaml
+++ b/examples/zero-click-loki/1-storage.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   resources:
     requests:
-      storage: 1G
+      storage: 200G
   volumeMode: Filesystem
   accessModes:
     - ReadWriteOnce


### PR DESCRIPTION
We are using these CRDs in our QE automation, and 1GB fills very quickly - this should remain a good example for customers wanting to "try it out" as this size works on even very small-scale (e.g. 3 worker node) clusters